### PR TITLE
don't redirect output of 'run' script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ ADD ./run.sh /scripts/run.sh
 # Set shell to bash
 ENV SHELL /bin/bash
 # Execute the script performing the operation (depending on environment variables)
-CMD cd /scripts && ./run.sh &> /tmp/consul-backup.log
+CMD cd /scripts && ./run.sh


### PR DESCRIPTION
if output of 'run' script is redirected, it doesn't get executed