### PR TITLE
Make backupfile name and version configurable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 1.0.8
+
+* Make name backup file configurable
+
 ### 1.0.7
 
 * Restore now supports "overwrite" mode

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN pip install --upgrade pip
 # Set some environment variables
 ENV CONSUL_HOST="consul.adsabs"
 ENV S3_BACKUP_FOLDER="adsabs-consul-backups"
+ENV BACKUP_FILE='adsabs_consul_kv'
 # Install Consul client
 RUN pip install consulate
 # The bash scripts for backup and restore

--- a/backup.py
+++ b/backup.py
@@ -63,7 +63,9 @@ if action == 'backup':
     # Get today's date for the time stamp
     now = str(datetime.datetime.now().date())
     # Construct the name of the backup file
-    backup_file = '%s/adsabs_consul_kv.%s.json' % (tmp_dir,now)
+    fname = os.environ.get('BACKUP_FILE','adsabs_consul_kv')
+    version = os.environ.get('VERSION',now)
+    backup_file = '%s/%s.%s.json' % (tmp_dir,fname,version)
     # Get the records from the Consul key/value store
     try:
         records = get_records_from_consul(session)
@@ -88,7 +90,8 @@ if action == 'backup':
     os.remove(backup_file)
 elif action == 'restore':
     # Construct the name of the backup file to retrieve
-    backup_file = '%s/adsabs_consul_kv.%s.json' % (tmp_dir,restore_id)
+    fname = os.environ.get('BACKUP_FILE','adsabs_consul_kv')
+    backup_file = '%s/%s.%s.json' % (tmp_dir,fname,restore_id)
     # Get the file from S3
     s3 = get_s3_resource()
     try:


### PR DESCRIPTION
Allow for override of default backup file name and versioning through environment variables. This allows for overrides in `runTask` on AWS ECS and boto3 `run_task` 
